### PR TITLE
fix: address code review findings across publisher, subscriber, config, and marshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ timestamp, ok := kafka.MessageTimestampFromContext(msg.Context())
 key, ok := kafka.MessageKeyFromContext(msg.Context())
 ```
 
+You can also set context values when building custom middleware or marshalers:
+
+```go
+ctx = kafka.ContextWithPartition(ctx, partition)
+ctx = kafka.ContextWithOffset(ctx, offset)
+ctx = kafka.ContextWithTimestamp(ctx, timestamp)
+ctx = kafka.ContextWithKey(ctx, key)
+```
+
 ### Authentication
 
 #### SASL/PLAIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@
 # The Kafka broker is available at localhost:9092
 # Internal communication uses kafka:29092
 
-version: '3.8'
-
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.3.5
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	github.com/twmb/franz-go v1.21.0
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
@@ -19,6 +18,7 @@ require (
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
 	golang.org/x/crypto v0.50.0 // indirect

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -128,6 +128,28 @@ type SubscriberConfig struct {
 	OverwriteKgoOpts []kgo.Opt
 }
 
+// setPublisherDefaults applies default values to zero-value fields in PublisherConfig.
+func setPublisherDefaults(config *PublisherConfig) {
+	if config.Marshaler == nil {
+		config.Marshaler = DefaultMarshaler{}
+	}
+	if config.MaxBufferedRecords == 0 {
+		config.MaxBufferedRecords = 10000
+	}
+	if config.ProduceRequestTimeout == 0 {
+		config.ProduceRequestTimeout = 10 * time.Second
+	}
+	if config.BatchMaxBytes == 0 {
+		config.BatchMaxBytes = 1 << 20 // 1MB
+	}
+	if len(config.Compression) == 0 {
+		config.Compression = []kgo.CompressionCodec{kgo.SnappyCompression(), kgo.NoCompression()}
+	}
+	if config.ClientID == "" {
+		config.ClientID = "watermill"
+	}
+}
+
 // DefaultPublisherConfig returns a PublisherConfig with sensible defaults.
 func DefaultPublisherConfig() PublisherConfig {
 	return PublisherConfig{

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -155,8 +155,3 @@ func DefaultSubscriberConfig() SubscriberConfig {
 		ClientID:               "watermill",
 	}
 }
-
-// GenerateClientID generates a unique client ID.
-func GenerateClientID() string {
-	return "watermill-kafka-franz"
-}

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -111,6 +111,10 @@ type SubscriberConfig struct {
 	// Defaults to 0 (no sleep). Use DefaultSubscriberConfig() for a pre-filled 100ms default.
 	NackResendSleep time.Duration
 
+	// CommitTimeout is the timeout for manual offset commits when DisableAutoCommit is true.
+	// Defaults to 10 seconds. Increase for high-latency clusters.
+	CommitTimeout time.Duration
+
 	// TLS configuration for secure connections.
 	TLS *tls.Config
 
@@ -208,5 +212,6 @@ func DefaultSubscriberConfig() SubscriberConfig {
 		ClientID:                         "watermill",
 		InitializeTopicPartitions:        1,
 		InitializeTopicReplicationFactor: 1,
+		CommitTimeout:                    10 * time.Second,
 	}
 }

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"crypto/tls"
+	"errors"
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -126,6 +127,28 @@ type SubscriberConfig struct {
 	// OverwriteKgoOpts allows passing arbitrary franz-go options.
 	// Use with caution - these options may override settings above.
 	OverwriteKgoOpts []kgo.Opt
+}
+
+// Validate checks that the PublisherConfig has all required fields set.
+func (c PublisherConfig) Validate() error {
+	if len(c.Brokers) == 0 {
+		return errors.New("brokers must not be empty")
+	}
+	if c.Marshaler == nil {
+		return errors.New("marshaler must not be nil")
+	}
+	return nil
+}
+
+// Validate checks that the SubscriberConfig has all required fields set.
+func (c SubscriberConfig) Validate() error {
+	if len(c.Brokers) == 0 {
+		return errors.New("brokers must not be empty")
+	}
+	if c.Unmarshaler == nil {
+		return errors.New("unmarshaler must not be nil")
+	}
+	return nil
 }
 
 // setPublisherDefaults applies default values to zero-value fields in PublisherConfig.

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -195,15 +195,15 @@ func DefaultPublisherConfig() PublisherConfig {
 // DefaultSubscriberConfig returns a SubscriberConfig with sensible defaults.
 func DefaultSubscriberConfig() SubscriberConfig {
 	return SubscriberConfig{
-		AutoOffsetReset:        "latest",
-		HeartbeatInterval:      3 * time.Second,
-		SessionTimeout:         45 * time.Second,
-		RebalanceTimeout:       60 * time.Second,
-		AutoCommitInterval:     5 * time.Second,
-		FetchMinBytes:          1,
-		FetchMaxBytes:          50 << 20, // 50MB
-		FetchMaxPartitionBytes: 1 << 20,  // 1MB
-		FetchMaxWait:           5 * time.Second,
+		AutoOffsetReset:                  "latest",
+		HeartbeatInterval:                3 * time.Second,
+		SessionTimeout:                   45 * time.Second,
+		RebalanceTimeout:                 60 * time.Second,
+		AutoCommitInterval:               5 * time.Second,
+		FetchMinBytes:                    1,
+		FetchMaxBytes:                    50 << 20, // 50MB
+		FetchMaxPartitionBytes:           1 << 20,  // 1MB
+		FetchMaxWait:                     5 * time.Second,
 		NackResendSleep:                  100 * time.Millisecond,
 		ClientID:                         "watermill",
 		InitializeTopicPartitions:        1,

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -108,7 +108,7 @@ type SubscriberConfig struct {
 	FetchMaxWait time.Duration
 
 	// NackResendSleep sets how long to sleep before resending a nacked message.
-	// Defaults to 100ms. Set to 0 for no sleep.
+	// Defaults to 0 (no sleep). Use DefaultSubscriberConfig() for a pre-filled 100ms default.
 	NackResendSleep time.Duration
 
 	// TLS configuration for secure connections.

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -127,6 +127,14 @@ type SubscriberConfig struct {
 	// OverwriteKgoOpts allows passing arbitrary franz-go options.
 	// Use with caution - these options may override settings above.
 	OverwriteKgoOpts []kgo.Opt
+
+	// InitializeTopicPartitions is the number of partitions for topics created by SubscribeInitialize.
+	// Defaults to 1.
+	InitializeTopicPartitions int32
+
+	// InitializeTopicReplicationFactor is the replication factor for topics created by SubscribeInitialize.
+	// Defaults to 1.
+	InitializeTopicReplicationFactor int16
 }
 
 // Validate checks that the PublisherConfig has all required fields set.
@@ -196,7 +204,9 @@ func DefaultSubscriberConfig() SubscriberConfig {
 		FetchMaxBytes:          50 << 20, // 50MB
 		FetchMaxPartitionBytes: 1 << 20,  // 1MB
 		FetchMaxWait:           5 * time.Second,
-		NackResendSleep:        100 * time.Millisecond,
-		ClientID:               "watermill",
+		NackResendSleep:                  100 * time.Millisecond,
+		ClientID:                         "watermill",
+		InitializeTopicPartitions:        1,
+		InitializeTopicReplicationFactor: 1,
 	}
 }

--- a/pkg/kafka/config_test.go
+++ b/pkg/kafka/config_test.go
@@ -79,6 +79,68 @@ func TestDefaultSubscriberConfig(t *testing.T) {
 	}
 }
 
+func TestPublisherConfig_Validate(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		config := DefaultPublisherConfig()
+		config.Brokers = []string{"localhost:9092"}
+		config.Marshaler = DefaultMarshaler{}
+		if err := config.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("empty brokers", func(t *testing.T) {
+		config := DefaultPublisherConfig()
+		config.Marshaler = DefaultMarshaler{}
+		err := config.Validate()
+		if err == nil {
+			t.Error("expected error for empty brokers")
+		}
+	})
+
+	t.Run("nil marshaler", func(t *testing.T) {
+		config := PublisherConfig{
+			Brokers:   []string{"localhost:9092"},
+			Marshaler: nil,
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Error("expected error for nil marshaler")
+		}
+	})
+}
+
+func TestSubscriberConfig_Validate(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		config := DefaultSubscriberConfig()
+		config.Brokers = []string{"localhost:9092"}
+		config.Unmarshaler = DefaultMarshaler{}
+		if err := config.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("empty brokers", func(t *testing.T) {
+		config := DefaultSubscriberConfig()
+		config.Unmarshaler = DefaultMarshaler{}
+		err := config.Validate()
+		if err == nil {
+			t.Error("expected error for empty brokers")
+		}
+	})
+
+	t.Run("nil unmarshaler", func(t *testing.T) {
+		config := SubscriberConfig{
+			Brokers:     []string{"localhost:9092"},
+			Unmarshaler: nil,
+		}
+		err := config.Validate()
+		if err == nil {
+			t.Error("expected error for nil unmarshaler")
+		}
+	})
+}
+
 func TestConfigWithOverwriteKgoOpts(t *testing.T) {
 	// Test PublisherConfig with custom kgo options
 	pubConfig := DefaultPublisherConfig()

--- a/pkg/kafka/context.go
+++ b/pkg/kafka/context.go
@@ -19,26 +19,6 @@ const (
 	messageKey contextKey = "message_key"
 )
 
-// setPartitionToCtx adds partition info to context (internal helper).
-func setPartitionToCtx(ctx context.Context, partition int32) context.Context {
-	return context.WithValue(ctx, partitionKey, partition)
-}
-
-// setPartitionOffsetToCtx adds offset info to context (internal helper).
-func setPartitionOffsetToCtx(ctx context.Context, offset int64) context.Context {
-	return context.WithValue(ctx, offsetKey, offset)
-}
-
-// setMessageTimestampToCtx adds timestamp info to context (internal helper).
-func setMessageTimestampToCtx(ctx context.Context, timestamp time.Time) context.Context {
-	return context.WithValue(ctx, timestampKey, timestamp)
-}
-
-// setMessageKeyToCtx adds message key info to context (internal helper).
-func setMessageKeyToCtx(ctx context.Context, key []byte) context.Context {
-	return context.WithValue(ctx, messageKey, key)
-}
-
 // ContextWithPartition adds partition info to context.
 func ContextWithPartition(ctx context.Context, partition int32) context.Context {
 	return context.WithValue(ctx, partitionKey, partition)
@@ -61,10 +41,20 @@ func OffsetFromContext(ctx context.Context) (int64, bool) {
 	return offset, ok
 }
 
+// ContextWithTimestamp adds message timestamp to context.
+func ContextWithTimestamp(ctx context.Context, timestamp time.Time) context.Context {
+	return context.WithValue(ctx, timestampKey, timestamp)
+}
+
 // MessageTimestampFromContext extracts message timestamp from context.
 func MessageTimestampFromContext(ctx context.Context) (time.Time, bool) {
 	timestamp, ok := ctx.Value(timestampKey).(time.Time)
 	return timestamp, ok
+}
+
+// ContextWithKey adds message key to context.
+func ContextWithKey(ctx context.Context, key []byte) context.Context {
+	return context.WithValue(ctx, messageKey, key)
 }
 
 // MessageKeyFromContext extracts message key from context.

--- a/pkg/kafka/marshaler.go
+++ b/pkg/kafka/marshaler.go
@@ -1,8 +1,9 @@
 package kafka
 
 import (
+	"fmt"
+
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/pkg/errors"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -26,7 +27,7 @@ type DefaultMarshaler struct{}
 func (DefaultMarshaler) Marshal(topic string, msg *message.Message) (*kgo.Record, error) {
 	// Reject reserved header key
 	if value := msg.Metadata.Get(UUIDHeaderKey); value != "" {
-		return nil, errors.Errorf("metadata %s is reserved for message UUID", UUIDHeaderKey)
+		return nil, fmt.Errorf("metadata %s is reserved for message UUID", UUIDHeaderKey)
 	}
 
 	// Build headers: UUID header + metadata headers
@@ -64,7 +65,7 @@ type PartitionedMarshaler struct{}
 func (PartitionedMarshaler) Marshal(topic string, msg *message.Message) (*kgo.Record, error) {
 	// Reject reserved header key
 	if value := msg.Metadata.Get(UUIDHeaderKey); value != "" {
-		return nil, errors.Errorf("metadata %s is reserved for message UUID", UUIDHeaderKey)
+		return nil, fmt.Errorf("metadata %s is reserved for message UUID", UUIDHeaderKey)
 	}
 
 	// Build headers: UUID header + metadata headers

--- a/pkg/kafka/marshaler.go
+++ b/pkg/kafka/marshaler.go
@@ -52,21 +52,7 @@ func (DefaultMarshaler) Marshal(topic string, msg *message.Message) (*kgo.Record
 
 // Unmarshal converts a Kafka record to a Watermill message.
 func (DefaultMarshaler) Unmarshal(record *kgo.Record) (*message.Message, error) {
-	var messageID string
-	metadata := make(message.Metadata, len(record.Headers))
-
-	for _, header := range record.Headers {
-		if header.Key == UUIDHeaderKey {
-			messageID = string(header.Value)
-		} else {
-			metadata.Set(header.Key, string(header.Value))
-		}
-	}
-
-	msg := message.NewMessage(messageID, record.Value)
-	msg.Metadata = metadata
-
-	return msg, nil
+	return unmarshalRecord(record)
 }
 
 // PartitionedMarshaler is a marshaler that uses message UUID as the Kafka key
@@ -105,6 +91,13 @@ func (PartitionedMarshaler) Marshal(topic string, msg *message.Message) (*kgo.Re
 
 // Unmarshal converts a Kafka record to a Watermill message.
 func (PartitionedMarshaler) Unmarshal(record *kgo.Record) (*message.Message, error) {
+	return unmarshalRecord(record)
+}
+
+// unmarshalRecord is the shared implementation for unmarshaling Kafka records
+// into Watermill messages. It extracts the UUID from the reserved header and
+// maps remaining headers to message metadata.
+func unmarshalRecord(record *kgo.Record) (*message.Message, error) {
 	var messageID string
 	metadata := make(message.Metadata, len(record.Headers))
 

--- a/pkg/kafka/publisher.go
+++ b/pkg/kafka/publisher.go
@@ -90,18 +90,13 @@ func (p *Publisher) Publish(topic string, msgs ...*message.Message) error {
 			return fmt.Errorf("cannot marshal message %s: %w", msg.UUID, err)
 		}
 
-		// Set context for cancellation/timeout
-		// Note: We don't use msg.Context() here because it may be cancelled
-		// The record context is used for request-scoped values, not for cancellation
 		record.Context = context.Background()
 		records[i] = record
 	}
 
-	// Use background context for publishing
-	// Message contexts may be cancelled and shouldn't affect publishing
-	ctx := context.Background()
+	ctx, ctxCancel := context.WithTimeout(context.Background(), p.config.ProduceRequestTimeout)
+	defer ctxCancel()
 
-	// Synchronous production
 	result := p.client.ProduceSync(ctx, records...)
 	if err := result.FirstErr(); err != nil {
 		return fmt.Errorf("cannot produce messages: %w", err)

--- a/pkg/kafka/publisher.go
+++ b/pkg/kafka/publisher.go
@@ -2,11 +2,12 @@ package kafka
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/pkg/errors"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -57,7 +58,7 @@ func NewPublisher(config PublisherConfig, logger watermill.LoggerAdapter) (*Publ
 
 	client, err := kgo.NewClient(opts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot create kafka client")
+		return nil, fmt.Errorf("cannot create kafka client: %w", err)
 	}
 
 	return &Publisher{
@@ -84,7 +85,7 @@ func (p *Publisher) Publish(topic string, msgs ...*message.Message) error {
 	for i, msg := range msgs {
 		record, err := p.config.Marshaler.Marshal(topic, msg)
 		if err != nil {
-			return errors.Wrapf(err, "cannot marshal message %s", msg.UUID)
+			return fmt.Errorf("cannot marshal message %s: %w", msg.UUID, err)
 		}
 
 		// Set context for cancellation/timeout
@@ -101,7 +102,7 @@ func (p *Publisher) Publish(topic string, msgs ...*message.Message) error {
 	// Synchronous production
 	result := p.client.ProduceSync(ctx, records...)
 	if err := result.FirstErr(); err != nil {
-		return errors.Wrap(err, "cannot produce messages")
+		return fmt.Errorf("cannot produce messages: %w", err)
 	}
 
 	// Log success with partition/offset info from first record

--- a/pkg/kafka/publisher.go
+++ b/pkg/kafka/publisher.go
@@ -25,6 +25,10 @@ type Publisher struct {
 func NewPublisher(config PublisherConfig, logger watermill.LoggerAdapter) (*Publisher, error) {
 	setPublisherDefaults(&config)
 
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid publisher config: %w", err)
+	}
+
 	if logger == nil {
 		logger = watermill.NopLogger{}
 	}

--- a/pkg/kafka/publisher.go
+++ b/pkg/kafka/publisher.go
@@ -23,9 +23,7 @@ type Publisher struct {
 
 // NewPublisher creates a new Kafka Publisher.
 func NewPublisher(config PublisherConfig, logger watermill.LoggerAdapter) (*Publisher, error) {
-	if config.Marshaler == nil {
-		config.Marshaler = DefaultMarshaler{}
-	}
+	setPublisherDefaults(&config)
 
 	if logger == nil {
 		logger = watermill.NopLogger{}

--- a/pkg/kafka/publisher_test.go
+++ b/pkg/kafka/publisher_test.go
@@ -54,14 +54,9 @@ func TestNewPublisher_InvalidBrokers(t *testing.T) {
 	logger := watermill.NewStdLogger(false, false)
 	publisher, err := NewPublisher(config, logger)
 
-	// franz-go allows empty brokers initially but will fail when used
-	// The publisher is created but connection will fail later
-	if err != nil {
-		assert.Nil(t, publisher)
-	} else {
-		// Clean up if it was created
-		_ = publisher.Close()
-	}
+	assert.Error(t, err)
+	assert.Nil(t, publisher)
+	assert.Contains(t, err.Error(), "brokers must not be empty")
 }
 
 func TestPublisher_Publish_SingleMessage(t *testing.T) {

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -159,7 +159,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 		time.Sleep(2 * time.Second)
 
 		for {
-			// Poll for records
+			client.AllowRebalance()
 			fetches := client.PollFetches(runCtx)
 
 			// Check if we should exit

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -141,7 +141,6 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 	go func() {
 		defer s.subscribersWg.Done()
 		defer close(output)
-		defer client.Close()
 
 		// Create a context that is cancelled when the subscriber is closing
 		runCtx, cancel := context.WithCancel(ctx)

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -318,12 +318,11 @@ ResendLoop:
 			break ResendLoop
 
 		case <-msg.Nacked():
-			// Copy and retry
 			msg = msg.Copy()
 			msg.SetContext(ContextWithPartition(
 				ContextWithOffset(
 					ContextWithTimestamp(
-						ContextWithKey(ctx, record.Key),
+						ContextWithKey(context.WithoutCancel(ctx), record.Key),
 						record.Timestamp,
 					),
 					record.Offset,

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -110,10 +110,17 @@ func setSubscriberDefaults(config SubscriberConfig) SubscriberConfig {
 	if config.InitializeTopicReplicationFactor == 0 {
 		config.InitializeTopicReplicationFactor = 1
 	}
+	if config.CommitTimeout == 0 {
+		config.CommitTimeout = 10 * time.Second
+	}
 	return config
 }
 
 // Subscribe implements message.Subscriber.
+//
+// Delivery guarantee: at-least-once. During consumer group rebalancing, a message
+// that was delivered but not yet Acked may be redelivered to this or another consumer.
+// Handlers must be idempotent.
 func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
 	if atomic.LoadUint32(&s.closed) == 1 {
 		return nil, errors.New("subscriber closed")
@@ -329,7 +336,7 @@ ResendLoop:
 
 			// Manual commit if auto-commit disabled
 			if s.config.DisableAutoCommit {
-				commitCtx, commitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				commitCtx, commitCancel := context.WithTimeout(context.Background(), s.config.CommitTimeout)
 				if err := client.CommitRecords(commitCtx, record); err != nil {
 					s.logger.Error("Cannot commit offset", err, nil)
 				}

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -187,13 +187,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 					continue
 				}
 
-				// Topic filtering is not strictly necessary here because each client is topic-isolated,
-				// but it's good practice.
-				if record.Topic != topic {
-					continue
-				}
-
-				msg, err := s.config.Unmarshaler.Unmarshal(record)
+			msg, err := s.config.Unmarshaler.Unmarshal(record)
 				if err != nil {
 					s.logger.Error("Cannot unmarshal message", err, nil)
 					continue

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -100,9 +100,7 @@ func setSubscriberDefaults(config SubscriberConfig) SubscriberConfig {
 	if config.FetchMinBytes == 0 {
 		config.FetchMinBytes = 1
 	}
-	if config.NackResendSleep == 0 {
-		config.NackResendSleep = 100 * time.Millisecond
-	}
+
 	if config.ClientID == "" {
 		config.ClientID = "watermill"
 	}
@@ -264,6 +262,7 @@ func (s *Subscriber) subscriberOptions(topic string) []kgo.Opt {
 	if s.config.ConsumerGroup != "" {
 		opts = append(opts,
 			kgo.ConsumerGroup(s.config.ConsumerGroup),
+			kgo.BlockRebalanceOnPoll(),
 			kgo.HeartbeatInterval(s.config.HeartbeatInterval),
 			kgo.SessionTimeout(s.config.SessionTimeout),
 			kgo.RebalanceTimeout(s.config.RebalanceTimeout),

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -151,6 +151,10 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 	go func() {
 		defer s.subscribersWg.Done()
 		defer close(output)
+		// Close the client when the goroutine exits so it leaves the consumer group
+		// immediately (e.g. on context cancellation). kgo.Client.Close is idempotent,
+		// so the additional close in Subscriber.Close is safe.
+		defer client.Close()
 
 		// Create a context that is cancelled when the subscriber is closing
 		runCtx, cancel := context.WithCancel(ctx)

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -262,7 +262,8 @@ func (s *Subscriber) subscriberOptions(topic string) []kgo.Opt {
 	if s.config.ConsumerGroup != "" {
 		opts = append(opts,
 			kgo.ConsumerGroup(s.config.ConsumerGroup),
-			kgo.BlockRebalanceOnPoll(),
+			// BlockRebalanceOnPoll is NOT enabled: handleMessage blocks per-record
+			// waiting for Ack/Nack, which would prevent rebalances and deadlock.
 			kgo.HeartbeatInterval(s.config.HeartbeatInterval),
 			kgo.SessionTimeout(s.config.SessionTimeout),
 			kgo.RebalanceTimeout(s.config.RebalanceTimeout),

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -106,6 +106,12 @@ func setSubscriberDefaults(config SubscriberConfig) SubscriberConfig {
 	if config.ClientID == "" {
 		config.ClientID = "watermill"
 	}
+	if config.InitializeTopicPartitions == 0 {
+		config.InitializeTopicPartitions = 1
+	}
+	if config.InitializeTopicReplicationFactor == 0 {
+		config.InitializeTopicReplicationFactor = 1
+	}
 	return config
 }
 
@@ -391,7 +397,7 @@ func (s *Subscriber) SubscribeInitialize(topic string) error {
 	}
 
 	// Create topic with default config (1 partition, replication factor 1)
-	resp, err := adminClient.CreateTopics(ctx, 1, 1, nil, topic)
+	resp, err := adminClient.CreateTopics(ctx, s.config.InitializeTopicPartitions, s.config.InitializeTopicReplicationFactor, nil, topic)
 	if err != nil {
 		return fmt.Errorf("cannot create topic: %w", err)
 	}

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -93,6 +93,15 @@ func setSubscriberDefaults(config SubscriberConfig) SubscriberConfig {
 	if config.FetchMaxWait == 0 {
 		config.FetchMaxWait = 5 * time.Second
 	}
+	if config.FetchMinBytes == 0 {
+		config.FetchMinBytes = 1
+	}
+	if config.NackResendSleep == 0 {
+		config.NackResendSleep = 100 * time.Millisecond
+	}
+	if config.ClientID == "" {
+		config.ClientID = "watermill"
+	}
 	return config
 }
 

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -195,10 +195,10 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 
 				// Enrich context with Kafka metadata
 				// Use context.WithoutCancel to preserve values but avoid carrying over cancellation
-				recordCtx := setPartitionToCtx(context.WithoutCancel(runCtx), record.Partition)
-				recordCtx = setPartitionOffsetToCtx(recordCtx, record.Offset)
-				recordCtx = setMessageTimestampToCtx(recordCtx, record.Timestamp)
-				recordCtx = setMessageKeyToCtx(recordCtx, record.Key)
+				recordCtx := ContextWithPartition(context.WithoutCancel(runCtx), record.Partition)
+				recordCtx = ContextWithOffset(recordCtx, record.Offset)
+				recordCtx = ContextWithTimestamp(recordCtx, record.Timestamp)
+				recordCtx = ContextWithKey(recordCtx, record.Key)
 
 				msgCtx, cancelMsg := context.WithCancel(recordCtx)
 				msg.SetContext(msgCtx)
@@ -304,10 +304,10 @@ ResendLoop:
 		case <-msg.Nacked():
 			// Copy and retry
 			msg = msg.Copy()
-			msg.SetContext(setPartitionToCtx(
-				setPartitionOffsetToCtx(
-					setMessageTimestampToCtx(
-						setMessageKeyToCtx(ctx, record.Key),
+			msg.SetContext(ContextWithPartition(
+				ContextWithOffset(
+					ContextWithTimestamp(
+						ContextWithKey(ctx, record.Key),
 						record.Timestamp,
 					),
 					record.Offset,

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -2,13 +2,14 @@ package kafka
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/pkg/errors"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -53,7 +54,7 @@ func NewSubscriber(config SubscriberConfig, logger watermill.LoggerAdapter) (*Su
 
 	adminClient, err := kgo.NewClient(adminOpts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot create admin kafka client")
+		return nil, fmt.Errorf("cannot create admin kafka client: %w", err)
 	}
 
 	return &Subscriber{
@@ -108,7 +109,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 
 	client, err := kgo.NewClient(opts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot create kafka client")
+		return nil, fmt.Errorf("cannot create kafka client: %w", err)
 	}
 
 	s.subClientsMu.Lock()
@@ -368,7 +369,7 @@ func (s *Subscriber) SubscribeInitialize(topic string) error {
 	// Check if topic exists
 	topics, err := adminClient.ListTopics(ctx)
 	if err != nil {
-		return errors.Wrap(err, "cannot list topics")
+		return fmt.Errorf("cannot list topics: %w", err)
 	}
 
 	if _, exists := topics[topic]; exists {
@@ -379,7 +380,7 @@ func (s *Subscriber) SubscribeInitialize(topic string) error {
 	// Create topic with default config (1 partition, replication factor 1)
 	resp, err := adminClient.CreateTopics(ctx, 1, 1, nil, topic)
 	if err != nil {
-		return errors.Wrap(err, "cannot create topic")
+		return fmt.Errorf("cannot create topic: %w", err)
 	}
 
 	if err := resp[topic].Err; err != nil {
@@ -388,7 +389,7 @@ func (s *Subscriber) SubscribeInitialize(topic string) error {
 			s.logger.Debug("Topic already exists", watermill.LogFields{"topic": topic})
 			return nil
 		}
-		return errors.Wrapf(err, "cannot create topic %s", topic)
+		return fmt.Errorf("cannot create topic %s: %w", topic, err)
 	}
 
 	s.logger.Info("Created Kafka topic", watermill.LogFields{"topic": topic})

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -35,6 +35,10 @@ type Subscriber struct {
 func NewSubscriber(config SubscriberConfig, logger watermill.LoggerAdapter) (*Subscriber, error) {
 	config = setSubscriberDefaults(config)
 
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid subscriber config: %w", err)
+	}
+
 	if logger == nil {
 		logger = watermill.NopLogger{}
 	}

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -311,9 +311,11 @@ ResendLoop:
 
 			// Manual commit if auto-commit disabled
 			if s.config.DisableAutoCommit {
-				if err := client.CommitRecords(msg.Context(), record); err != nil {
+				commitCtx, commitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				if err := client.CommitRecords(commitCtx, record); err != nil {
 					s.logger.Error("Cannot commit offset", err, nil)
 				}
+				commitCancel()
 			}
 			break ResendLoop
 

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -198,20 +198,20 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 				return
 			}
 
-		// Handle errors - log them but still process any valid records in this fetch.
-		// A single fetch can contain both errors and valid records.
-		for _, err := range fetches.Errors() {
-			// Skip context canceled errors (normal shutdown)
-			if err.Err == context.Canceled {
-				continue
+			// Handle errors - log them but still process any valid records in this fetch.
+			// A single fetch can contain both errors and valid records.
+			for _, err := range fetches.Errors() {
+				// Skip context canceled errors (normal shutdown)
+				if err.Err == context.Canceled {
+					continue
+				}
+				// Log all errors but don't exit - franz-go handles retries internally
+				s.logger.Debug("Fetch error", watermill.LogFields{
+					"error":     err.Err.Error(),
+					"topic":     err.Topic,
+					"partition": err.Partition,
+				})
 			}
-			// Log all errors but don't exit - franz-go handles retries internally
-			s.logger.Debug("Fetch error", watermill.LogFields{
-				"error":     err.Err.Error(),
-				"topic":     err.Topic,
-				"partition": err.Partition,
-			})
-		}
 
 			// Process records
 			iter := fetches.RecordIter()
@@ -221,7 +221,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 					continue
 				}
 
-			msg, err := s.config.Unmarshaler.Unmarshal(record)
+				msg, err := s.config.Unmarshaler.Unmarshal(record)
 				if err != nil {
 					s.logger.Error("Cannot unmarshal message", err, nil)
 					continue

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -181,23 +181,20 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 				return
 			}
 
-			// Handle errors - log them but continue polling to allow recovery
-			if errs := fetches.Errors(); len(errs) > 0 {
-				for _, err := range errs {
-					// Skip context canceled errors (normal shutdown)
-					if err.Err == context.Canceled {
-						continue
-					}
-					// Log all errors but don't exit - franz-go handles retries internally
-					s.logger.Debug("Fetch error", watermill.LogFields{
-						"error":     err.Err.Error(),
-						"topic":     err.Topic,
-						"partition": err.Partition,
-					})
-				}
-				// Continue polling - franz-go handles reconnection
+		// Handle errors - log them but still process any valid records in this fetch.
+		// A single fetch can contain both errors and valid records.
+		for _, err := range fetches.Errors() {
+			// Skip context canceled errors (normal shutdown)
+			if err.Err == context.Canceled {
 				continue
 			}
+			// Log all errors but don't exit - franz-go handles retries internally
+			s.logger.Debug("Fetch error", watermill.LogFields{
+				"error":     err.Err.Error(),
+				"topic":     err.Topic,
+				"partition": err.Partition,
+			})
+		}
 
 			// Process records
 			iter := fetches.RecordIter()

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -126,6 +126,16 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 	// in concurrent polling scenarios.
 	opts := s.subscriberOptions(topic)
 
+	partitionsReady := make(chan struct{}, 1)
+	if s.config.ConsumerGroup != "" {
+		opts = append(opts, kgo.OnPartitionsAssigned(func(_ context.Context, _ *kgo.Client, _ map[string][]int32) {
+			select {
+			case partitionsReady <- struct{}{}:
+			default:
+			}
+		}))
+	}
+
 	client, err := kgo.NewClient(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create kafka client: %w", err)
@@ -154,9 +164,13 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 			}
 		}()
 
-		// Wait for consumer group to join and get partition assignments
-		// This is critical for tests to ensure consumer is ready before messages are published
-		time.Sleep(2 * time.Second)
+		if s.config.ConsumerGroup != "" {
+			select {
+			case <-partitionsReady:
+			case <-runCtx.Done():
+				return
+			}
+		}
 
 		for {
 			client.AllowRebalance()


### PR DESCRIPTION
## Background/Description

Comprehensive code review fixes for the watermill-kafka-franz library addressing 17 issues found during review, plus 2 follow-up fixes from PR feedback.

### Critical Fixes
- **AllowRebalance()**: Added `client.AllowRebalance()` before `PollFetches` for cooperative rebalancing support. `BlockRebalanceOnPoll` is intentionally NOT enabled — watermill's per-message Ack/Nack pattern blocks in `handleMessage` between poll iterations, which would prevent rebalances from completing and cause deadlocks with concurrent consumers.
- **Fetch error handling**: Fixed `continue` that discarded valid records when a fetch contained both errors and valid records
- **Double-close prevention**: Restored `defer client.Close()` in goroutine for proper consumer group cleanup when context is cancelled
- **Nack context**: Fixed nack resend using `context.WithoutCancel` to match initial delivery behavior
- **CommitRecords context**: Use `context.Background()` with timeout instead of potentially-cancelled message context
- **ProduceSync timeout**: Use configurable `ProduceRequestTimeout` instead of bare `context.Background()`
- **Consumer readiness**: Replaced hardcoded `time.Sleep(2s)` with `OnPartitionsAssigned` callback

### Config & API Improvements
- Added `Validate()` methods for `PublisherConfig` and `SubscriberConfig`
- Added `setPublisherDefaults()` for symmetric config handling
- Fixed missing `NackResendSleep`, `FetchMinBytes`, `ClientID` defaults in `setSubscriberDefaults()`
- Restored `NackResendSleep: 0` as valid no-sleep option (was being overwritten to 100ms)
- Made `SubscribeInitialize` partitions/replicas configurable via `InitializeTopicPartitions` and `InitializeTopicReplicationFactor`

### Code Quality
- Extracted shared `unmarshalRecord()` to deduplicate `DefaultMarshaler`/`PartitionedMarshaler`
- Deduplicated context helpers into single public API (`ContextWith*` functions)
- Migrated from `github.com/pkg/errors` to standard library `fmt.Errorf`
- Removed dead topic filter code in subscriber
- Removed deprecated docker-compose version field

### Breaking Change Note
- `GenerateClientID()` exported function was removed (was unused dead code returning a hardcoded string). This is a compile-time breaking change for any downstream code calling this function. No version tags exist (pre-v1), so impact is minimal.

## Type of Change
- [x] bug fix (non breaking)
- [x] New feature (non breaking)
- [x] Breaking change (fix or feature that may break current functionality)

## Proof of work
- All unit tests pass (`go test -short -race ./...`)
- All integration tests pass (`go test -v -race -timeout 10m ./...` — 62s with Kafka via docker-compose)
- Linter passes (`golangci-lint run ./...` — 0 issues)