### PR TITLE
feat: add Stop() to subscriber for graceful shutdown

### DIFF
--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -379,12 +379,12 @@ ResendLoop:
 }
 
 // Stop signals the subscriber to stop consuming new messages while allowing
-// in-flight messages to be acked or nacked. After Stop, Subscribe will reject
-// new subscriptions. Existing subscription goroutines finish processing their
-// current batch and then exit.
+// in-flight messages to be acked or nacked. After Stop, Subscribe and
+// SubscribeInitialize will reject new calls. Existing subscription goroutines
+// finish processing their current batch and then exit.
 //
-// Stop is intended for graceful shutdown scenarios where a router (or caller)
-// wants to drain in-flight work before fully closing the subscriber with Close.
+// Stop is intended for graceful shutdown scenarios. Call Stop first to drain
+// in-flight messages, then call Close to complete the shutdown.
 //
 // It is safe to call Stop multiple times.
 func (s *Subscriber) Stop() error {
@@ -428,6 +428,10 @@ func (s *Subscriber) Close() error {
 func (s *Subscriber) SubscribeInitialize(topic string) error {
 	if atomic.LoadUint32(&s.closed) == 1 {
 		return errors.New("subscriber closed")
+	}
+
+	if atomic.LoadUint32(&s.stopped) == 1 {
+		return errors.New("subscriber stopped")
 	}
 
 	// Create admin client

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -23,6 +23,8 @@ type Subscriber struct {
 	// adminClient is used for SubscribeInitialize
 	adminClient *kgo.Client
 
+	stopping      chan struct{}
+	stopped       uint32 // atomic
 	closing       chan struct{}
 	subscribersWg sync.WaitGroup
 	closed        uint32 // atomic
@@ -65,6 +67,7 @@ func NewSubscriber(config SubscriberConfig, logger watermill.LoggerAdapter) (*Su
 		config:      config,
 		logger:      logger,
 		adminClient: adminClient,
+		stopping:    make(chan struct{}),
 		closing:     make(chan struct{}),
 	}, nil
 }
@@ -126,6 +129,10 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 		return nil, errors.New("subscriber closed")
 	}
 
+	if atomic.LoadUint32(&s.stopped) == 1 {
+		return nil, errors.New("subscriber stopped")
+	}
+
 	// Create a new client for this subscription to ensure isolation.
 	// Dedicated clients are used to prevent cross-topic message "stealing"
 	// in concurrent polling scenarios.
@@ -167,7 +174,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 
 		go func() {
 			select {
-			case <-s.closing:
+			case <-s.stopping:
 				cancel()
 			case <-runCtx.Done():
 			}
@@ -371,11 +378,33 @@ ResendLoop:
 	return nil
 }
 
+// Stop signals the subscriber to stop consuming new messages while allowing
+// in-flight messages to be acked or nacked. After Stop, Subscribe will reject
+// new subscriptions. Existing subscription goroutines finish processing their
+// current batch and then exit.
+//
+// Stop is intended for graceful shutdown scenarios where a router (or caller)
+// wants to drain in-flight work before fully closing the subscriber with Close.
+//
+// It is safe to call Stop multiple times.
+func (s *Subscriber) Stop() error {
+	if !atomic.CompareAndSwapUint32(&s.stopped, 0, 1) {
+		return nil
+	}
+
+	s.logger.Debug("Subscriber: stopping subscriber", nil)
+	close(s.stopping)
+	return nil
+}
+
 // Close implements message.Subscriber.
 func (s *Subscriber) Close() error {
 	if !atomic.CompareAndSwapUint32(&s.closed, 0, 1) {
 		return nil
 	}
+
+	// Stop fetching new messages first.
+	_ = s.Stop()
 
 	s.logger.Debug("Subscriber: closing subscriber", nil)
 	close(s.closing)

--- a/pkg/kafka/subscriber_test.go
+++ b/pkg/kafka/subscriber_test.go
@@ -73,3 +73,64 @@ func TestSubscribeInitialize_ClosedSubscriber(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "subscriber closed")
 }
+
+func TestStop_RejectsNewSubscriptions(t *testing.T) {
+	config := DefaultSubscriberConfig()
+	config.Brokers = []string{"127.0.0.1:9092"}
+
+	logger := watermill.NewStdLogger(false, false)
+	subscriber, err := NewSubscriber(config, logger)
+	require.NoError(t, err)
+	defer func() { _ = subscriber.Close() }()
+
+	err = subscriber.Stop()
+	require.NoError(t, err)
+
+	_, err = subscriber.Subscribe(t.Context(), "test-topic")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "subscriber stopped")
+}
+
+func TestStop_Idempotent(t *testing.T) {
+	config := DefaultSubscriberConfig()
+	config.Brokers = []string{"127.0.0.1:9092"}
+
+	logger := watermill.NewStdLogger(false, false)
+	subscriber, err := NewSubscriber(config, logger)
+	require.NoError(t, err)
+	defer func() { _ = subscriber.Close() }()
+
+	require.NoError(t, subscriber.Stop())
+	require.NoError(t, subscriber.Stop())
+	require.NoError(t, subscriber.Stop())
+}
+
+func TestClose_AlsoStops(t *testing.T) {
+	config := DefaultSubscriberConfig()
+	config.Brokers = []string{"127.0.0.1:9092"}
+
+	logger := watermill.NewStdLogger(false, false)
+	subscriber, err := NewSubscriber(config, logger)
+	require.NoError(t, err)
+
+	err = subscriber.Close()
+	require.NoError(t, err)
+
+	_, err = subscriber.Subscribe(t.Context(), "test-topic")
+	assert.Error(t, err)
+}
+
+func TestStop_ThenClose(t *testing.T) {
+	config := DefaultSubscriberConfig()
+	config.Brokers = []string{"127.0.0.1:9092"}
+
+	logger := watermill.NewStdLogger(false, false)
+	subscriber, err := NewSubscriber(config, logger)
+	require.NoError(t, err)
+
+	require.NoError(t, subscriber.Stop())
+	require.NoError(t, subscriber.Close())
+
+	_, err = subscriber.Subscribe(t.Context(), "test-topic")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Background/Description

During graceful shutdown, the Watermill router calls `subscriber.Close()` which immediately cancels in-flight message handling. Messages that were being processed lose the chance to be acked or nacked, causing double-handling when the consumer rejoins.

This adds a `Stop()` method that implements a two-phase shutdown:

1. **Stop()** — closes the `stopping` channel, which cancels the poll loop context. New `PollFetches` calls return immediately and the subscription goroutine winds down. However, `handleMessage` still only reacts to `s.closing`, so in-flight messages can still be acked or nacked.
2. **Close()** — calls `Stop()` first (for backward compatibility), then closes `s.closing` to force-quit any remaining `handleMessage` waits, waits for goroutines, and cleans up clients.

The gap between `Stop()` and `Close()` is the grace period where handlers can finish processing.

`Subscribe()` rejects new subscriptions after `Stop()` is called.

Relates to ThreeDotsLabs/watermill#446

## Type of Change

- [ ] bug fix (non breaking)
- [x] New feature (non breaking)
- [ ] Breaking change (fix or feature that may break current functionality)
- [ ] Requires documentation change

## Proof of work

```
go build ./...    # ✅ compiles
make lint         # ✅ 0 issues
go test -short -v ./...  # ✅ 4 new tests pass, 4 integration tests skipped
```

New unit tests:
- `TestStop_RejectsNewSubscriptions` — Stop() then Subscribe() returns error
- `TestStop_Idempotent` — multiple Stop() calls return nil
- `TestClose_AlsoStops` — Close() internally calls Stop()
- `TestStop_ThenClose` — Stop() followed by Close() works correctly
